### PR TITLE
add multiple templates for github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Create a report to help us improve
+label: bug
+---
+<!-- Provide a general summary of the bug in the title above. -->
+
+<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
+<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
+
+## Describe the Bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## System Information
+
+ - Operating system:
+ - Rave version:
+
+## Additional Context
+
+<!-- Add any other relevant information about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature or changes to existing features
+label: enhancement
+---
+<!--- Provide a general summary of the changes you want in the title above. -->
+
+<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
+<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
+
+## Feature Request Type
+
+- [ ] Core functionality
+- [ ] Alteration (enhancement/optimization) of existing feature(s)
+- [ ] New behavior
+
+## Description
+
+<!-- A few sentences describing what it is that you'd like to see in Rave. -->

--- a/.github/ISSUE_TEMPLATE/other_issues.md
+++ b/.github/ISSUE_TEMPLATE/other_issues.md
@@ -1,0 +1,7 @@
+---
+name: Other issues
+about: Anything else that doesn't fall into the above categories.
+---
+<!--- Provide a general summary of the changes you want in the title above. -->
+
+<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->


### PR DESCRIPTION
This PR adds GitHub issue templates according to [the latest Github guidelines for multiple issue templates](https://help.github.com/en/articles/about-issue-and-pull-request-templates).

Added three templates:
- bug report template with `bug` label
- feature request template with `enhancement ` label
- other issues template